### PR TITLE
[!!!][BUGFIX] Check if processes were successful

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -15,7 +15,7 @@ ARTEFACT_PREFIX="typo3_src-"
 
 COMPOSER_INSTALL_COMMAND="composer install --ignore-platform-reqs --no-dev -o"
 CHECKSUM_SHA_COMMAND="shasum -a %1\$s %2\$s"
-CHECKSUM_MD5_COMMAND="md5sum %2\$s"
+CHECKSUM_MD5_COMMAND="md5sum %1\$s"
 
 AZURE_CONNECTIONSTRING=""
 AZURE_CONTAINER="typo3"

--- a/src/Application.php
+++ b/src/Application.php
@@ -11,6 +11,7 @@ namespace TYPO3\Darth;
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 
@@ -195,7 +196,11 @@ class Application extends \Symfony\Component\Console\Application
     {
         // remove any old info
         if (@is_dir($directory)) {
-            (new Process('sudo rm -rf ' . $directory))->run();
+            $process = new Process('sudo rm -rf ' . $directory);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
         }
         mkdir($directory);
     }

--- a/src/Command/AnnounceCommand.php
+++ b/src/Command/AnnounceCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use TYPO3\Darth\Application;
 use TYPO3\Darth\GitHelper;
@@ -275,6 +276,9 @@ class AnnounceCommand extends Command
             $this->getApplication()->getArtefactsDirectory($version)
         );
         $process->run();
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
 
         $output = $process->getOutput();
         if ($output === '') {

--- a/src/Command/InitializeCommand.php
+++ b/src/Command/InitializeCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use TYPO3\Darth\Application;
 use TYPO3\Darth\GitHelper;
@@ -74,7 +75,11 @@ class InitializeCommand extends Command
 
         // Download the latest Gerrit commit hook
         if (getenv('GERRIT_COMMIT_HOOK')) {
-            (new Process(getenv('GERRIT_COMMIT_HOOK'), $workingDirectory))->run();
+            $process = new Process(getenv('GERRIT_COMMIT_HOOK'), $workingDirectory);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
         }
 
         // Check if the signing key is set

--- a/src/Command/PackageCommand.php
+++ b/src/Command/PackageCommand.php
@@ -140,13 +140,15 @@ class PackageCommand extends Command
 
         // Legacy code
         // Show MD5 hashes and SHA1 hashes
+        $md5Command = sprintf(getenv('CHECKSUM_MD5_COMMAND'), '*.gz *.zip');
         $this->io->note(
             "MD5 hashes of the artefacts:\n"
-            . $this->runProcess('md5sum *.gz *.zip', $artefactsDirectory)->getOutput()
+            . $this->runProcess($md5Command, $artefactsDirectory)->getOutput()
         );
+        $shaCommand = sprintf(getenv('CHECKSUM_SHA_COMMAND'), '1', '*.gz *.zip');
         $this->io->note(
             "SHA1 hashes of the artefacts:\n"
-            . $this->runProcess('sha1sum *.gz *.zip', $artefactsDirectory)->getOutput()
+            . $this->runProcess($shaCommand, $artefactsDirectory)->getOutput()
         );
 
         $this->io->success('All done. Just upload it now with the "publish" process.');

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use TYPO3\Darth\Application;
 use TYPO3\Darth\GitHelper;
@@ -206,10 +207,15 @@ class ReleaseCommand extends Command
 
         if ($sprintRelease) {
             $this->io->note('Update composer.lock file');
-            (new Process(
+            $process = new Process(
                 'composer update --lock',
                 $this->getApplication()->getWorkingDirectory()
-            ))->setTimeout(null)->run();
+            );
+            $process->setTimeout(null);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
         }
 
         $commitMessage = '[TASK] Set TYPO3 version to ' . $upcomingVersion . '-dev';

--- a/src/GitHelper.php
+++ b/src/GitHelper.php
@@ -15,6 +15,7 @@ use GitWrapper\Event\GitOutputStreamListener;
 use GitWrapper\GitException;
 use GitWrapper\GitWorkingCopy;
 use GitWrapper\GitWrapper;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 /**
@@ -340,7 +341,11 @@ class GitHelper
         $this->git->push('origin', 'HEAD:refs/for/' . $remoteBranch);
         // Auto approve by gerrit
         if (getenv('GERRIT_AUTO_APPROVE_COMMAND')) {
-            (new Process(getenv('GERRIT_AUTO_APPROVE_COMMAND') . ' ' . $commitHash, $this->workingDirectory))->run();
+            $process = new Process(getenv('GERRIT_AUTO_APPROVE_COMMAND') . ' ' . $commitHash, $this->workingDirectory);
+            $process->run();
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
         }
     }
 }

--- a/src/Service/FileHashService.php
+++ b/src/Service/FileHashService.php
@@ -9,6 +9,7 @@ namespace TYPO3\Darth\Service;
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class FileHashService
@@ -50,15 +51,9 @@ class FileHashService
         $command = $this->getCommand($algorithmName, $filePattern);
         $process = new Process($command, $this->workingDirectory);
         $process->run();
-        if ($process->getExitCode() !== 0) {
-            throw new \RuntimeException(
-                sprintf(
-                    "Command \"%s\" failed:\n%s",
-                    $command,
-                    $process->getErrorOutput()
-                ),
-                1522925350
-            );
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
         }
         return trim($process->getOutput(), "- \n\r");
     }


### PR DESCRIPTION
Symfony's Process class swallows errors from executed commands unless
the exit state explicitly checked. This is a rather unexpected but
documented behavior, and may lead to broken releases.

All `Process` usages are now guarded by a `isSuccessful` check.

---

❗ `.env` command for `md5` has been changed - individual overrides have to updated locally

```patch
-CHECKSUM_MD5_COMMAND="md5sum %2\$s"
+CHECKSUM_MD5_COMMAND="md5sum %1\$s"
``` 