### PR TITLE
[BUGFIX] Adapt labels & fix md5 command

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -15,7 +15,7 @@ ARTEFACT_PREFIX="typo3_src-"
 
 COMPOSER_INSTALL_COMMAND="composer install --ignore-platform-reqs --no-dev -o"
 CHECKSUM_SHA_COMMAND="shasum -a %1\$s %2\$s"
-CHECKSUM_MD5_COMMAND="md5sum %1\$s"
+CHECKSUM_MD5_COMMAND="md5sum %2\$s"
 
 AZURE_CONNECTIONSTRING=""
 AZURE_CONTAINER="typo3"

--- a/src/Command/AnnounceCommand.php
+++ b/src/Command/AnnounceCommand.php
@@ -179,7 +179,7 @@ class AnnounceCommand extends Command
         if ($interactive) {
             $this->io->note(
                 'The current release notes file has been prepared for further '
-                . ' adjustments at ' . $releaseNotesPath
+                . 'adjustments at ' . $releaseNotesPath
             );
             $answer = $this->io->confirm(
                 'All modified? Ready to continue?',

--- a/src/Command/PackageCommand.php
+++ b/src/Command/PackageCommand.php
@@ -140,7 +140,7 @@ class PackageCommand extends Command
 
         // Legacy code
         // Show MD5 hashes and SHA1 hashes
-        $md5Command = sprintf(getenv('CHECKSUM_MD5_COMMAND'), '*.gz *.zip');
+        $md5Command = sprintf(getenv('CHECKSUM_MD5_COMMAND'), '', '*.gz *.zip');
         $this->io->note(
             "MD5 hashes of the artefacts:\n"
             . $this->runProcess($md5Command, $artefactsDirectory)->getOutput()
@@ -152,6 +152,7 @@ class PackageCommand extends Command
         );
 
         $this->io->success('All done. Just upload it now with the "publish" process.');
+        $this->io->comment('./bin/darth publish ' . $version);
     }
 
     /**

--- a/src/Command/PublishCommand.php
+++ b/src/Command/PublishCommand.php
@@ -105,7 +105,8 @@ class PublishCommand extends Command
         if ($hasErrors) {
             $this->io->error('Some files could not be uploaded, you should probably upload them manually from ' . $artefactsDirectory);
         } else {
-            $this->io->success('All done. Enjoy the rest of your day!');
+            $this->io->success('All done. Only the announcement is missing now!');
+            $this->io->comment('./bin/darth announce ' . ltrim($version, 'v') . ' [LINK]');
         }
     }
 

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -133,7 +133,7 @@ class ReleaseCommand extends Command
             $this->updateFilesWithVersions($workingDirectory, $filesToManipulate, $sprintRelease, $nextVersion);
         }
 
-        // Now commit with "[RELEASE] Released TYPO3 v.x.x"
+        // Now commit with "[RELEASE] Released TYPO3 x.y.z"
         $commitMessage = '[RELEASE] Release of TYPO3 ' . $nextVersion;
         if ($input->hasOption('commitMessage') && $input->getOption('commitMessage')) {
             $commitMessage .= "\n\n" . $input->getOption('commitMessage');
@@ -231,6 +231,7 @@ class ReleaseCommand extends Command
         }
 
         $this->io->success('Release is done, now go on with packaging by using the "package" command');
+        $this->io->comment('./bin/darth package  ' . $nextVersion);
 
         return 0;
     }


### PR DESCRIPTION
The md5 check in the package command
is adapted to allow $2.

In addition, some more additions to the
output is added to enable an easier
workflow.