### PR TITLE
[BUGFIX] Use proper remote branch detection

### DIFF
--- a/src/GitHelper.php
+++ b/src/GitHelper.php
@@ -118,9 +118,8 @@ class GitHelper
         $usedBranch = null;
         foreach ($branches as $branchObj) {
             $branch = $branchObj->getName();
-            if (preg_match('/remotes\/origin\/([A-z0-9_-]+' . str_replace('.', '-', $nextMinorVersion) . '|' . str_replace('.', '\.', $nextMinorVersion) . ')/', $branch)) {
-                // subtract the "remotes/" part
-                $usedBranch = substr($branch, 8);
+            if (preg_match('/origin\/([A-z0-9_-]+' . str_replace('.', '-', $nextMinorVersion) . '|' . str_replace('.', '\.', $nextMinorVersion) . ')/', $branch)) {
+                $usedBranch = $branch;
                 break;
             }
         }


### PR DESCRIPTION
Due to the exchange of the underlying Git
library, the remote branches did not start
with "remotes/origin/10.4" but just "origin/10.4",

For this reason, the remote branch detection did
not work anymore.

The preg_replace is now changed.