### PR TITLE
[TASK] Update all dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,18 +9,18 @@
 		}
 	],
 	"require": {
-		"php": "^7.4 || ^8.0",
-		"symfony/finder": "^6.0",
-		"symfony/dotenv": "^6.0",
-		"symfony/console": "^6.0",
-		"symfony/yaml": "^6.0",
-		"typo3fluid/fluid": "^2.7",
-		"microsoft/azure-storage": "^0.16.0",
-		"gitonomy/gitlib": "^1.3"
+		"php": "^8.1",
+		"gitonomy/gitlib": "^1.3.7",
+		"microsoft/azure-storage-blob": "^1.5.4",
+		"symfony/console": "^6.2.8",
+		"symfony/dotenv": "^6.2.8",
+		"symfony/finder": "^6.2.7",
+		"symfony/yaml": "^6.2.7",
+		"typo3fluid/fluid": "^2.7.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9",
-		"typo3/coding-standards": "^0.7"
+		"phpunit/phpunit": "^10.0.19",
+		"typo3/coding-standards": "^0.7.1"
 	},
 	"autoload": {
 		"psr-4": {
@@ -30,6 +30,7 @@
 	"config": {
 		"platform": {
 			"php": "8.1.0"
-		}
+		},
+		"sort-packages": true
 	}
 }

--- a/src/Command/AnnounceCommand.php
+++ b/src/Command/AnnounceCommand.php
@@ -211,7 +211,6 @@ class AnnounceCommand extends Command
         return 0;
     }
 
-
     /**
      * Stub for allowing proper IDE support.
      *

--- a/src/Command/ConfigurationCommand.php
+++ b/src/Command/ConfigurationCommand.php
@@ -68,7 +68,6 @@ class ConfigurationCommand extends Command
         return 0;
     }
 
-
     /**
      * Stub for allowing proper IDE support.
      *

--- a/src/Command/InitializeCommand.php
+++ b/src/Command/InitializeCommand.php
@@ -88,7 +88,6 @@ class InitializeCommand extends Command
         return 0;
     }
 
-
     /**
      * Stub for allowing proper IDE support.
      *

--- a/src/Command/PackageCommand.php
+++ b/src/Command/PackageCommand.php
@@ -368,7 +368,6 @@ class PackageCommand extends Command
         return $process;
     }
 
-
     /**
      * Stub for allowing proper IDE support.
      *

--- a/src/Command/PublishCommand.php
+++ b/src/Command/PublishCommand.php
@@ -111,7 +111,6 @@ class PublishCommand extends Command
         return 0;
     }
 
-
     /**
      * Stub for allowing proper IDE support.
      *

--- a/src/Command/SecurityCommand.php
+++ b/src/Command/SecurityCommand.php
@@ -251,7 +251,6 @@ class SecurityCommand extends Command
         return $this->fetched[$url];
     }
 
-
     /**
      * Stub for allowing proper IDE support.
      *

--- a/src/Uploader/AzureUploader.php
+++ b/src/Uploader/AzureUploader.php
@@ -11,24 +11,18 @@ namespace TYPO3\Darth\Uploader;
  * file that was distributed with this source code.
  */
 
+use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Blob\Internal\IBlob;
-use MicrosoftAzure\Storage\Common\ServicesBuilder;
 
 class AzureUploader implements UploaderInterface
 {
-    /**
-     * @var IBlob
-     */
-    private $client;
+    private IBlob $client;
 
-    /**
-     * @var string
-     */
-    private $containerName;
+    private string $containerName;
 
     public function __construct()
     {
-        $this->client = ServicesBuilder::getInstance()->createBlobService(getenv('AZURE_CONNECTIONSTRING'));
+        $this->client = BlobRestProxy::createBlobService(getenv('AZURE_CONNECTIONSTRING'));
         $this->containerName = getenv('AZURE_CONTAINER');
     }
 


### PR DESCRIPTION
This change adds phpunit 10 and
the new azure blob storage package,
thus allowing to upgrade guzzle to v7
and all other dependencies.

A "composer bump" command is now
used in order to require the latest
versions currently in use.