### PR TITLE
[BUGFIX] Avoid using --ignore-platform-reqs

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -13,7 +13,7 @@ GERRIT_COMMIT_HOOK="wget -q --no-check-certificate -O .git/hooks/commit-msg http
 
 ARTEFACT_PREFIX="typo3_src-"
 
-COMPOSER_INSTALL_COMMAND="composer install --ignore-platform-reqs --no-dev -o"
+COMPOSER_INSTALL_COMMAND="composer install --no-dev -o"
 CHECKSUM_SHA_COMMAND="shasum -a %1\$s %2\$s"
 CHECKSUM_MD5_COMMAND="md5sum %2\$s"
 


### PR DESCRIPTION
With https://github.com/typo3/typo3/commit/4ab93f353cbf4d4eefd83891923e60c0c61897bb the check for the required PHP version was removed to relay on the Composer platform check. Using `--ignore-platform-reqs` does not include this check and users using the packages generated by Darth my run into troubles while using a not supported PHP version.