### PR TITLE
[TASK] Gracefully handle a missing previous post-release commit

### DIFF
--- a/conf/release.yaml
+++ b/conf/release.yaml
@@ -24,7 +24,7 @@ updateFiles:
     type: "bugfixVersion"
   -
     file: "typo3/sysext/*/composer.json"
-    pattern: '"typo3\/cms-[^"]+"\s*:\s*"((?:[6-9]|[1-9][0-9])\.[0-9]+\.\*@dev)'
+    pattern: '"typo3\/cms-[^"]+"\s*:\s*"((?:[6-9]|[1-9][0-9])\.[0-9]+\.[^"]+")'
     type: "bugfixVersion"
   -
     file: "typo3/sysext/core/Classes/Core/SystemEnvironmentBuilder.php"


### PR DESCRIPTION
Ensure extension composer.json files are properly updated if they have not been updated to require @dev versions before. This might happen if the post-release commit
(like "Set to TYPO3 version X.Y.Z-dev") could not
be transferred to the release branch.