### PR TITLE
[TASK] Remove EXT:styleguide from packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 	],
 	"require": {
 		"php": "^8.1",
+		"ext-json": "*",
 		"gitonomy/gitlib": "^1.3.7",
 		"microsoft/azure-storage-blob": "^1.5.4",
 		"symfony/console": "^6.2.8",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	"require": {
 		"php": "^8.1",
 		"ext-json": "*",
+		"composer/composer": "^2.6",
 		"gitonomy/gitlib": "^1.3.7",
 		"microsoft/azure-storage-blob": "^1.5.4",
 		"symfony/console": "^6.2.8",

--- a/conf/release.yaml
+++ b/conf/release.yaml
@@ -83,6 +83,8 @@ excludeFromPackaging:
     - ".svn"
     - ".travis.yml"
     - ".appveyor.yml"
+  "typo3/sysext/":
+    - "styleguide"
   "vendor/**":
     - "Test"
     - "tests"
@@ -97,6 +99,11 @@ executableFilesInPackage:
   - "*.sh"
   - "*.pl"
   - "typo3/sysext/core/bin/typo3"
+
+removeFromComposerJson:
+  - "replace.typo3/cms-styleguide"
+  - "autoload.psr-4.TYPO3\\CMS\\Styleguide\\"
+  - "autoload-dev.psr-4.TYPO3\\CMS\\Styleguide\\Tests\\"
 
 announce:
   endpoints:

--- a/src/Command/PackageCommand.php
+++ b/src/Command/PackageCommand.php
@@ -11,6 +11,7 @@ namespace TYPO3\Darth\Command;
  * file that was distributed with this source code.
  */
 
+use Composer\Json\JsonFile;
 use Gitonomy\Git\Repository;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -211,20 +212,13 @@ class PackageCommand extends Command
     {
         $removeFromComposerJson = $this->getApplication()->getConfiguration('removeFromComposerJson');
         $composerJsonFile = $directory . '/composer.json';
-        $payload = json_decode(
-            file_get_contents($composerJsonFile),
-            true,
-            64,
-            JSON_THROW_ON_ERROR
-        );
+        // see https://github.com/composer/composer/blob/2.6.6/src/Composer/Json/JsonFile.php
+        $composerJson = new JsonFile($composerJsonFile);
+        $payload = $composerJson->read();
         foreach ($removeFromComposerJson as $jsonPath) {
             $payload = $this->removeFromArray($payload, $jsonPath, true);
         }
-        file_put_contents(
-            $composerJsonFile,
-            // see https://github.com/composer/composer/blob/2.6.6/src/Composer/Json/JsonFile.php#L137
-            json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
-        );
+        $composerJson->write($payload);
     }
 
     /**


### PR DESCRIPTION
Since `EXT:styleguide` is shipped in the mono-repository without using any local path repository and explicit `require` section, it is expected to be there. Just removing the directory in `typo3/sysext/styleguide` still would advertise the "existence" of that package internally to the Composer-based package manager.

Thus, the following adjustments are required to `composer.json`:

* drop `replace.typo3/cms-styleguide`
* drop `autoload.psr-4.TYPO3\CMS\Styleguide\`
* drop `autoload-dev.psr-4.TYPO3\CMS\Styleguide\Tests\`

The `composer.json` file is written directly by using the `composer/composer` package (which is a new dependency for `typo3/darth` now).

Fixes: #37

---

### How to test?

```sh
bin/darth init
bin/darth package 13.0 main --type=snapshot
bin/darth package 12.4.10 v12.4.10
```

* the `13.0` snapshot should not contain any `ext:styleguide` source code anymore
  ```sh
  grep -iR styleguide publish/13.0/typo3_src-13.0
  ```
* the (existing) `12.4.10` still shall be able to be packaged, the `composer.json` shall not be (much) different to the released version https://github.com/TYPO3/typo3/blob/v12.4.10/composer.json;
  spoiler: it's different for `keywords`, which should be adjusted in the `composer.json` of the mono-repo
  ```patch
  diff -ru publish/12.4.10/typo3_src-12.4.10/composer.json typo3_src-12.4.10/composer.json
  --- publish/12.4.10/typo3_src-12.4.10/composer.json	2024-01-22 13:31:30
  +++ typo3_src-12.4.10/composer.json	2024-01-16 09:57:46
  @@ -1,12 +1,7 @@
   {
   	"name": "typo3/cms",
   	"description": "TYPO3 CMS is a free open source Content Management Framework initially created by Kasper Skaarhoj and licensed under GNU/GPL.",
  -	"keywords": [
  -		"typo3",
  -		"cms",
  -		"content management system",
  -		"extbase"
  -	],
  +	"keywords": ["typo3", "cms", "content management system", "extbase"],
   	"homepage": "https://typo3.org/",
   	"type": "typo3-cms-core",
   	"license": "GPL-2.0-or-later",
  @@ -310,8 +305,8 @@
   			"TYPO3Tests\\TestEid\\": "typo3/sysext/core/Tests/Functional/Fixtures/Extensions/test_eid/Classes/",
   			"TYPO3Tests\\FluidTest\\": "typo3/sysext/fluid/Tests/Functional/Fixtures/Extensions/fluid_test/Classes/",
   			"TYPO3Tests\\TestTranslate\\": "typo3/sysext/fluid/Tests/Functional/Fixtures/Extensions/test_translate/Classes/",
  -			"TYPO3Tests\\FormCachingTests\\": "typo3/sysext/form/Tests/Functional/RequestHandling/Fixtures/Extensions/form_caching_tests/Classes/",
  -			"TYPO3Tests\\IrreTutorial\\": "typo3/sysext/core/Tests/Functional/Fixtures/Extensions/irre_tutorial/Classes/",
  +			"TYPO3Tests\\FormCachingTests\\" : "typo3/sysext/form/Tests/Functional/RequestHandling/Fixtures/Extensions/form_caching_tests/Classes/",
  +			"TYPO3Tests\\IrreTutorial\\" : "typo3/sysext/core/Tests/Functional/Fixtures/Extensions/irre_tutorial/Classes/",
   			"TYPO3Tests\\RequestMirror\\": "typo3/sysext/frontend/Tests/Functional/Fixtures/Extensions/test_request_mirror/Classes/",
   			"TYPO3Tests\\TestValidators\\": "typo3/sysext/extbase/Tests/Functional/Fixtures/Extensions/test_validators/Classes/",
   			"TYPO3Tests\\TestDatahandler\\": "typo3/sysext/core/Tests/Functional/Fixtures/Extensions/test_datahandler/Classes
  ```