### PR TITLE
[TASK] Replace `COMPOSER_ROOT_VERSION` in `Build/Scripts/runTests.sh`

### DIFF
--- a/conf/release.yaml
+++ b/conf/release.yaml
@@ -53,6 +53,11 @@ updateFiles:
     file: "Build/composer/composer.dist.json"
     pattern: '"typo3\/cms-[^"]+": "(\d+\.\d+\.x-dev)"'
     type: "nextDevBranchAlias"
+  # ensure 13.0.x-dev is replaced by 13.1.x-dev
+  -
+    file: "Build/Scripts/runTests.sh"
+    pattern: 'COMPOSER_ROOT_VERSION="(\d+\.\d+\.x-dev)"'
+    type: "nextDevBranchAlias"
   # ensure 12.0.x-dev is replaced by 12.1.x-dev
   -
     file: "typo3/sysext/*/ext_emconf.php"


### PR DESCRIPTION
The `COMPOSER_ROOT_VERSION` variable has been reintroduced into
the `Build/Scripts/runTests.sh` wrapping script quite some time
ago. Until now, this value has been required to be adjusted by
hand, which can and have been missed.

This change modifies the release configuration to set the script
variable to the `dev branch alias` value and ensure the correct
version during future releases.

Note: Except branching after a LTS for the next major cycle needs
to be set to `<major>.0.x-dev` manually in the main branch after
splitting.

Resolves: #41
