### PR TITLE
[BUGFIX] Fix RELEASE commit for composer test distribution

### DIFF
--- a/conf/release.yaml
+++ b/conf/release.yaml
@@ -27,6 +27,10 @@ updateFiles:
     pattern: '"typo3\/cms-[^"]+"\s*:\s*"((?:[6-9]|[1-9][0-9])\.[0-9]+\.\*@dev)'
     type: "bugfixVersion"
   -
+    file: "Build/composer/composer.dist.json"
+    pattern: '"typo3\/cms-[^"]+": "(\d+\.\d+\.(\d+|x)-dev)"'
+    type: "bugfixVersion"
+  -
     file: "typo3/sysext/core/Classes/Core/SystemEnvironmentBuilder.php"
     pattern: '\''TYPO3_version\'',\s*\''([^\'']+)'
     type: "nextDevVersion"
@@ -48,11 +52,11 @@ updateFiles:
     file: "composer.json"
     pattern: '"dev-main": "(\d+\.\d+\.x-dev)"'
     type: "nextDevBranchAlias"
-  # ensure 9.2.x-dev is replaced by 9.3.x-dev
+  # ensure 9.3.0 is replaced by 9.3.1-dev
   -
     file: "Build/composer/composer.dist.json"
-    pattern: '"typo3\/cms-[^"]+": "(\d+\.\d+\.x-dev)"'
-    type: "nextDevBranchAlias"
+    pattern: '"typo3\/cms-[^"]+": "(\d+\.\d+\.\d+)"'
+    type: "nextDevVersion"
   # ensure 13.0.x-dev is replaced by 13.1.x-dev
   -
     file: "Build/Scripts/runTests.sh"


### PR DESCRIPTION
Previous RELEASE commits failed the "integration various pre-merge" test because the version map in composer.dist.json was not updated [1] from `12.4.x-dev` to `12.4.12`, therefore the version requirements in core extensions composer.json files like backend (requiring typo3/cms-core `v12.4.12` [1]) could not be fulfilled.
    
composer.dist.json is now updated once with:

* RELEASE: `12.4.x-dev` => `12.4.13`
* Set-DEV: `12.4.13` => `12.4.14-dev`

and with subsequent releases:

* RELEASE: `12.4.14-dev` => `12.4.14`
* Set-DEV: `12.4.14` => `12.4.15-dev`

That means we'll no longer use generic versions aliases (12.4.x-dev), but concrete ones (12.4.14-dev), as `nextDevBranchAlias` would only be  executed in Set-DEV for sprint releases, but we need to apply the Set-DEV change for every bugfix release.



Failure was:

```
Build/Scripts/runTests.sh -s composerTestDistribution -p 8.1
Loading composer repositories with package information Updating dependencies
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires typo3/cms-backend @dev -> satisfiable by typo3/cms-backend[12.4.x-dev].
    - typo3/cms-backend 12.4.x-dev requires typo3/cms-core 12.4.12 -> found typo3/cms-core[12.4.x-dev] but it does not match the constraint.
```

[1] https://github.com/TYPO3/typo3/blob/v12.4.12/Build/composer/composer.dist.json#L20
[2] https://github.com/TYPO3/typo3/blob/v12.4.12/typo3/sysext/backend/composer.json#L23