### PR TITLE
Remove phpstorm.meta.php from tarball installations

### DIFF
--- a/conf/release.yaml
+++ b/conf/release.yaml
@@ -86,6 +86,7 @@ excludeFromPackaging:
     - "*~"
     - ".travis.yml"
     - ".appveyor.yml"
+    - "phpstorm.meta.php"
   "**":
     - ".gitignore"
     - ".git/"

--- a/conf/release.yaml
+++ b/conf/release.yaml
@@ -86,7 +86,7 @@ excludeFromPackaging:
     - "*~"
     - ".travis.yml"
     - ".appveyor.yml"
-    - "phpstorm.meta.php"
+    - ".phpstorm.meta.php"
   "**":
     - ".gitignore"
     - ".git/"


### PR DESCRIPTION
References: https://forge.typo3.org/issues/106698