### PR TITLE
[TASK] Update to symfony 7 and require php 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,20 +9,20 @@
 		}
 	],
 	"require": {
-		"php": "^8.1",
+		"php": "^8.2",
 		"ext-json": "*",
 		"composer/composer": "^2.7.7",
 		"gitonomy/gitlib": "^1.3.7",
 		"guzzlehttp/guzzle": "^7.8",
 		"microsoft/azure-storage-blob": "^1.5.4",
-		"symfony/console": "^6.2.8",
-		"symfony/dotenv": "^6.2.8",
-		"symfony/finder": "^6.2.7",
-		"symfony/yaml": "^6.2.7",
-		"typo3fluid/fluid": "^2.7.4"
+		"symfony/console": "^7.4",
+		"symfony/dotenv": "7.4.0",
+		"symfony/finder": "^7.4",
+		"symfony/yaml": "^7.4",
+		"typo3fluid/fluid": "^4.6"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^10.0.19",
+		"phpunit/phpunit": "^11.5",
 		"typo3/coding-standards": "^0.8"
 	},
 	"autoload": {
@@ -30,9 +30,14 @@
 			"TYPO3\\Darth\\": "src/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"TYPO3\\Darth\\Tests\\": "tests/"
+		}
+	},
 	"config": {
 		"platform": {
-			"php": "8.1.0"
+			"php": "8.2.0"
 		},
 		"sort-packages": true
 	}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
   <testsuites>
     <testsuite name="Unit Tests">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Application.php
+++ b/src/Application.php
@@ -214,6 +214,9 @@ class Application extends \Symfony\Component\Console\Application
     private function getMainDirectory(): string
     {
         $scriptEntryPath = realpath($_SERVER['PWD'] . '/' . $_SERVER['PHP_SELF']);
+        if ($scriptEntryPath === false) {
+            throw new \RuntimeException('Could not determine main directory', 1774945737);
+        }
 
         return dirname(dirname($scriptEntryPath));
     }

--- a/src/Command/AnnounceCommand.php
+++ b/src/Command/AnnounceCommand.php
@@ -38,20 +38,13 @@ use TYPO3Fluid\Fluid\View\TemplateView;
  */
 class AnnounceCommand extends Command
 {
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
-
-    /**
-     * @var GitHelper
-     */
-    private $gitHelper;
+    private SymfonyStyle $io;
+    private GitHelper $gitHelper;
 
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('This command announces (or updates) a release to get.typo3.org')
             ->addArgument(
@@ -231,7 +224,7 @@ class AnnounceCommand extends Command
         return $versionDirectory . '/RELEASE_NOTES.md';
     }
 
-    private function createReleaseNotesFile(string $releaseNotesPath, array $variables)
+    private function createReleaseNotesFile(string $releaseNotesPath, array $variables): void
     {
         $template = $this->getApplication()->getConfigurationFileName(
             'RELEASE_NOTES.md'
@@ -269,7 +262,7 @@ class AnnounceCommand extends Command
         );
     }
 
-    private function readSignatureDate(string $version)
+    private function readSignatureDate(string $version): ?\DateTime
     {
         $process = Process::fromShellCommandline(
             'gpg --verify README.md',
@@ -306,7 +299,7 @@ class AnnounceCommand extends Command
         return new Client($settings);
     }
 
-    private function getConfiguration()
+    private function getConfiguration(): mixed
     {
         $configuration = $this->getApplication()->getConfiguration('announce');
         return $configuration;
@@ -319,7 +312,7 @@ class AnnounceCommand extends Command
      * @return array
      * @deprecated Not used anymore
      */
-    private function inferenceVersionConstraint(string $version, array $configuration, string $path)
+    private function inferenceVersionConstraint(string $version, array $configuration, string $path): array
     {
         $subjectReference = &$this->referencePath($configuration, $path);
         $candidate = $this->evaluate(array_keys($subjectReference), $version);
@@ -333,7 +326,7 @@ class AnnounceCommand extends Command
         return $configuration;
     }
 
-    private function &referencePath(array &$subject, string $path, $delimiter = '.')
+    private function &referencePath(array &$subject, string $path, string $delimiter = '.'): mixed
     {
         $steps = explode($delimiter, $path);
         $result = &$subject;
@@ -343,7 +336,7 @@ class AnnounceCommand extends Command
         return $result;
     }
 
-    private function evaluate(array $candidates, string $version)
+    private function evaluate(array $candidates, string $version): ?string
     {
         $matches = array_filter(
             $candidates,

--- a/src/Command/AnnounceCommand.php
+++ b/src/Command/AnnounceCommand.php
@@ -237,7 +237,7 @@ class AnnounceCommand extends Command
             'RELEASE_NOTES.md'
         );
         $view = new TemplateView();
-        $view->getTemplatePaths()->setTemplatePathAndFilename($template);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename($template);
         $view->assignMultiple($variables);
         file_put_contents($releaseNotesPath, $view->render());
     }

--- a/src/Command/ConfigurationCommand.php
+++ b/src/Command/ConfigurationCommand.php
@@ -24,15 +24,12 @@ use TYPO3\Darth\Service\DotEnvService;
  */
 class ConfigurationCommand extends Command
 {
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
+    private SymfonyStyle $io;
 
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('This command shows the current configuration to verify according settings.');
     }

--- a/src/Command/InitializeCommand.php
+++ b/src/Command/InitializeCommand.php
@@ -26,15 +26,12 @@ use TYPO3\Darth\GitHelper;
  */
 class InitializeCommand extends Command
 {
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
+    private SymfonyStyle $io;
 
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('This task cleans up previous left-overs, prepares a clean Git repository and checks for all tools needed.');
     }

--- a/src/Command/PackageCommand.php
+++ b/src/Command/PackageCommand.php
@@ -38,7 +38,7 @@ class PackageCommand extends Command
     /**
      * Configures the current command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addArgument(
@@ -184,7 +184,7 @@ class PackageCommand extends Command
      * @param string $revision
      * @param string $sourceCodeDirectory
      */
-    protected function prepare(Repository $git, string $revision, string $sourceCodeDirectory)
+    protected function prepare(Repository $git, string $revision, string $sourceCodeDirectory): void
     {
         $archiveFile = dirname($sourceCodeDirectory) . '/gitarchive-' . date('Ymd-His') . '-' . $revision . '.tar';
 
@@ -224,7 +224,7 @@ class PackageCommand extends Command
      *
      * @param string $directory
      */
-    protected function runComposerCommand(string $directory)
+    protected function runComposerCommand(string $directory): void
     {
         $composerCommand = getenv('COMPOSER_INSTALL_COMMAND');
         $this->io->note('Now running ' . $composerCommand);
@@ -263,7 +263,7 @@ class PackageCommand extends Command
      *
      * @param string $directory
      */
-    protected function removeFilesExcludedForPackaging(string $directory)
+    protected function removeFilesExcludedForPackaging(string $directory): void
     {
         $this->io->note('Removing test, development and example files not handled properly by git/composer');
         $excludeFilesFromPackaging = $this->getApplication()->getConfiguration('excludeFromPackaging');
@@ -300,7 +300,7 @@ class PackageCommand extends Command
      *
      * @param string $directory the full path to the directory containing all sources codes
      */
-    protected function setPermissionsForFilesForPackaging(string $directory)
+    protected function setPermissionsForFilesForPackaging(string $directory): void
     {
         // @todo: unsetting the permissions
         // find ${project-permissions.directory} -type f | xargs chmod a-x
@@ -336,7 +336,7 @@ class PackageCommand extends Command
      *
      * @return array
      */
-    protected function createAndSignArtefacts(string $sourceCodeDirectory, $version): array
+    protected function createAndSignArtefacts(string $sourceCodeDirectory, string $version): array
     {
         $artefactDirectory = $this->getApplication()->getArtefactsDirectory($version);
         $artefactBaseName = basename($sourceCodeDirectory);

--- a/src/Command/PackageCommand.php
+++ b/src/Command/PackageCommand.php
@@ -110,7 +110,7 @@ class PackageCommand extends Command
         $readmeTemplate = $this->getApplication()->getConfigurationFileName('README.md');
 
         $view = new TemplateView();
-        $view->getTemplatePaths()->setTemplatePathAndFilename($readmeTemplate);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename($readmeTemplate);
         $view->assignMultiple(
             [
                 'version' => $version,

--- a/src/Command/PublishCommand.php
+++ b/src/Command/PublishCommand.php
@@ -29,15 +29,12 @@ use TYPO3\Darth\Uploader\EltsUploader;
  */
 class PublishCommand extends Command
 {
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
+    private SymfonyStyle $io;
 
     /**
      * Configures the current command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addArgument(

--- a/src/Command/PublishCommand.php
+++ b/src/Command/PublishCommand.php
@@ -63,7 +63,7 @@ class PublishCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
         $this->io->title('Upload all files to the cloud');

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -37,7 +37,7 @@ class ReleaseCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this
             ->addArgument(

--- a/src/Command/SecurityCommand.php
+++ b/src/Command/SecurityCommand.php
@@ -30,36 +30,17 @@ use TYPO3\Darth\Model\Version;
  */
 class SecurityCommand extends Command
 {
-    /**
-     * @var SymfonyStyle
-     */
-    private $io;
-
-    /**
-     * @var Client
-     */
-    private $client;
-
-    /**
-     * @var Collection
-     */
-    private $collection;
-
-    /**
-     * @var GitHelper
-     */
-    private $gitHelper;
-
-    /**
-     * Local cache of content per URL
-     * @var array<string, string>
-     */
-    private $fetched = [];
+    private SymfonyStyle $io;
+    private Client $client;
+    private Collection $collection;
+    private GitHelper $gitHelper;
+    /** @var array<string, string> */
+    private array $fetched = [];
 
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setDescription('This command prepares security related data')
             ->addArgument(
@@ -138,7 +119,7 @@ class SecurityCommand extends Command
      * @param string $version
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function processVersion(string $version)
+    private function processVersion(string $version): void
     {
         $utc = new \DateTimeZone('UTC');
 

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -11,12 +11,11 @@ namespace TYPO3\Darth\Tests\Unit;
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Darth\Application;
 
-/**
- * @covers Application
- */
+#[CoversClass(className: Application::class)]
 class ApplicationTest extends TestCase
 {
     public function testIfApplicationThrowsExceptionWhenNoWorkingDirectoryEnvVariableIsSet(): void

--- a/tests/Unit/GitHelperTest.php
+++ b/tests/Unit/GitHelperTest.php
@@ -11,12 +11,11 @@ namespace TYPO3\Darth\Tests\Unit;
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Darth\GitHelper;
 
-/**
- * @covers GitHelper
- */
+#[CoversClass(className: GitHelper::class)]
 class GitHelperTest extends TestCase
 {
     public function testIfSpecificVersionIsResolvedCorrectly()


### PR DESCRIPTION
Updated:
- symfony components to require ^7.4 at least
- fluid standalone to ^4
- phpunit to ^11

One important detail:
Since symfony/dotenv 7.4.0 works as before, and
symfony/dotenv 7.4.7 introduced a change that
strips away the dollar sign from

  CHECKSUM_SHA_COMMAND="shasum -a %1\$s %2\$s"

to result in "shasum -a %1 %2". For this reason
it is pinned to 7.4.0 directly.